### PR TITLE
 Feat: Implement `/api/v1/books/{book_id}` Endpoint & Set Up CI/CD  

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Deploy to Server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          script: |
+            echo "Deployment starting..."
+
+            # Navigate to project directory
+            cd fastapi-book-project || exit 1
+            git fetch --all || exit 1
+            git pull origin main || exit 1
+
+            # Create virtual environment if it doesn't exist
+            if [ ! -d "venv" ]; then
+              python3 -m venv venv || exit 1
+            fi
+
+            # Activate virtual environment and install dependencies
+            source venv/bin/activate || exit 1
+            python -m pip install --upgrade pip || exit 1
+            pip install --upgrade -r requirements.txt || exit 1
+
+            # Stop existing application if running
+            if pgrep -x "uvicorn" > /dev/null; then
+              echo "Stopping existing application..."
+              killall uvicorn || exit 1
+              echo "Application stopped successfully"
+            else
+              echo "No existing application running"
+            fi
+
+            # Start the application
+            echo "Starting application..."
+            nohup uvicorn main:app --host 0.0.0.0 --port 8000 > app.log 2>&1 &
+            echo "Application started successfully"
+
+            # Tail logs
+            tail -f app.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: CI Pipeline
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,6 +1,6 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB
@@ -47,6 +47,12 @@ async def create_book(book: Book):
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
 
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id: int):
+    book = db.get_books().get(book_id)
+    if book is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found")
+    return book
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def update_book(book_id: int, book: Book) -> Book:


### PR DESCRIPTION
This PR adds the missing `/api/v1/books/{book_id}` endpoint to retrieve book details by ID. It also sets up a GitHub Actions CI/CD pipeline for testing and deployment.  

#### **Changes & Features:**  
✅ Implemented the `/api/v1/books/{book_id}` endpoint  
✅ Returns book details if found, otherwise responds with `404 Not Found`  
✅ Ensured `main.py` remains unchanged as per requirements  
✅ Set up GitHub Actions for:  
   - Running `pytest` on pull requests to `main`  
   - Deploying changes on merging to `main` 